### PR TITLE
feat: add auto-reset streak and auto-calculate rank features

### DIFF
--- a/FLEARN-back/README-docker.md
+++ b/FLEARN-back/README-docker.md
@@ -1,1 +1,0 @@
-# FLEARN Backend with Docker

--- a/FLEARN-back/docs/RANK_CALCULATION.md
+++ b/FLEARN-back/docs/RANK_CALCULATION.md
@@ -1,0 +1,315 @@
+# User Rank Auto-Calculation Feature
+
+## Overview
+
+This feature automatically calculates and updates user ranks based on their total subject experience (math, physics, biology, chemistry). The rank is calculated using the formula: `Rank Level = total(subject_exp) // 8000` and is updated automatically when user data is retrieved or experience is updated.
+
+## Rank System
+
+### Rank Formula
+
+```
+Total Experience = math_exp + phy_exp + bio_exp + chem_exp
+Rank Level = floor(Total Experience / 8000)
+```
+
+### Rank Names and Thresholds
+
+| Rank Level | Total Experience | Rank Name           |
+|------------|------------------|---------------------|
+| 0          | 0 - 7,999        | Beginner            |
+| 1          | 8,000 - 15,999   | Primary school      |
+| 2          | 16,000 - 23,999  | Secondary school    |
+| 3          | 24,000 - 31,999  | University student  |
+| 4          | 32,000 - 39,999  | Graduated           |
+| 5+         | 40,000+          | Professor           |
+
+**Note**: Professor is the highest rank and applies to all experience totals of 40,000 or above.
+
+## Implementation Details
+
+### Files Modified/Created
+
+1. **`middleware/streakHelper.js`** (MODIFIED)
+   - Added `calculateRank()` function
+   - Added `updateUserRankIfNeeded()` function
+   - Updated `checkAndResetUserStreak()` to also update rank
+   - Exported `RANK_NAMES` and `RANK_EXP_DIVISOR` constants
+
+2. **`routes/users.js`** (MODIFIED)
+   - Updated `PATCH /api/users/experience` to calculate and update rank when experience changes
+   - `GET /api/users/profile` now also updates rank (via `checkAndResetUserStreak`)
+   - `GET /api/users/profilebyid` now also updates rank (via `checkAndResetUserStreak`)
+
+3. **`tests/streakHelper.test.js`** (MODIFIED)
+   - Added comprehensive tests for `calculateRank()` function
+   - Tests cover all rank boundaries and edge cases
+
+### When Rank is Updated
+
+The rank is automatically recalculated and updated in two scenarios:
+
+1. **On Experience Update**: When `PATCH /api/users/experience` is called
+2. **On Profile Get**: When `GET /api/users/profile` or `GET /api/users/profilebyid` is called
+
+## API Behavior
+
+### Experience Update Endpoint
+
+#### PATCH /api/users/experience
+
+**Before**: Updated experience values only  
+**After**: Updates experience values AND automatically calculates and updates rank
+
+**Request**:
+```http
+PATCH /api/users/experience
+Authorization: Bearer <JWT_TOKEN>
+Content-Type: application/json
+
+{
+  "math_exp": 10000,
+  "phy_exp": 8000,
+  "bio_exp": 6000,
+  "chem_exp": 4000
+}
+```
+
+**Response**:
+```json
+{
+  "message": "Experience points and rank updated successfully",
+  "user": {
+    "user_id": "123e4567-e89b-12d3-a456-426614174000",
+    "name": "John Doe",
+    "math_exp": 10000,
+    "phy_exp": 8000,
+    "bio_exp": 6000,
+    "chem_exp": 4000,
+    "rank": "University student",  // Auto-calculated (28000 / 8000 = level 3)
+    ...
+  }
+}
+```
+
+### Profile Get Endpoints
+
+#### GET /api/users/profile
+#### GET /api/users/profilebyid?id={userId}
+
+**Before**: Returns user profile as-is  
+**After**: Checks and updates rank if needed before returning
+
+If the rank doesn't match the calculated rank based on current experience, it will be automatically updated before the response is sent.
+
+## Examples
+
+### Example 1: New User (Beginner)
+
+**User Stats**:
+- math_exp: 1000
+- phy_exp: 1500
+- bio_exp: 2000
+- chem_exp: 1000
+- **Total**: 5,500
+
+**Calculated Rank**: `floor(5500 / 8000) = 0` → **"Beginner"**
+
+### Example 2: Primary School Student
+
+**User Stats**:
+- math_exp: 3000
+- phy_exp: 3000
+- bio_exp: 3000
+- chem_exp: 3000
+- **Total**: 12,000
+
+**Calculated Rank**: `floor(12000 / 8000) = 1` → **"Primary school"**
+
+### Example 3: Secondary School Student
+
+**User Stats**:
+- math_exp: 6000
+- phy_exp: 5000
+- bio_exp: 4000
+- chem_exp: 5000
+- **Total**: 20,000
+
+**Calculated Rank**: `floor(20000 / 8000) = 2` → **"Secondary school"**
+
+### Example 4: University Student
+
+**User Stats**:
+- math_exp: 8000
+- phy_exp: 7000
+- bio_exp: 6000
+- chem_exp: 9000
+- **Total**: 30,000
+
+**Calculated Rank**: `floor(30000 / 8000) = 3` → **"University student"**
+
+### Example 5: Graduated
+
+**User Stats**:
+- math_exp: 10000
+- phy_exp: 9000
+- bio_exp: 8000
+- chem_exp: 8000
+- **Total**: 35,000
+
+**Calculated Rank**: `floor(35000 / 8000) = 4` → **"Graduated"**
+
+### Example 6: Professor
+
+**User Stats**:
+- math_exp: 12000
+- phy_exp: 11000
+- bio_exp: 10000
+- chem_exp: 9000
+- **Total**: 42,000
+
+**Calculated Rank**: `floor(42000 / 8000) = 5` → **"Professor"**
+
+### Example 7: Experience Update Triggers Rank Change
+
+**Before Update**:
+```json
+{
+  "math_exp": 5000,
+  "phy_exp": 2000,
+  "bio_exp": 0,
+  "chem_exp": 0,
+  "rank": "Beginner"  // Total: 7000
+}
+```
+
+**Request**:
+```http
+PATCH /api/users/experience
+{
+  "chem_exp": 2000
+}
+```
+
+**After Update**:
+```json
+{
+  "math_exp": 5000,
+  "phy_exp": 2000,
+  "bio_exp": 0,
+  "chem_exp": 2000,
+  "rank": "Primary school"  // Total: 9000, auto-upgraded!
+}
+```
+
+## Rank Progression Chart
+
+```
+Experience          Rank
+    0 |━━━━━━━━━━━━━━━━━━━━━━━━━━━━━| Beginner
+ 8000 |━━━━━━━━━━━━━━━━━━━━━━━━━━━━━| Primary school
+16000 |━━━━━━━━━━━━━━━━━━━━━━━━━━━━━| Secondary school
+24000 |━━━━━━━━━━━━━━━━━━━━━━━━━━━━━| University student
+32000 |━━━━━━━━━━━━━━━━━━━━━━━━━━━━━| Graduated
+40000 |━━━━━━━━━━━━━━━━━━━━━━━━━━━━━| Professor (max)
+  +∞  |━━━━━━━━━━━━━━━━━━━━━━━━━━━━━| Professor
+```
+
+## Testing
+
+### Run Unit Tests
+
+```bash
+cd FLEARN-back
+npm test tests/streakHelper.test.js
+```
+
+### Test Coverage
+
+The tests cover:
+- ✅ All rank boundaries (0, 8000, 16000, 24000, 32000, 40000)
+- ✅ Edge cases (just below/at rank boundaries)
+- ✅ Null/undefined experience values
+- ✅ Very high experience values
+- ✅ Balanced vs specialized learning scenarios
+- ✅ Correct divisor (8000) usage
+- ✅ Correct rank name array
+
+### Manual Testing Scenarios
+
+#### Test 1: Rank Upgrade on Experience Gain
+1. Create a user with 7500 total experience (Beginner)
+2. Add 1000 to any subject experience
+3. Verify rank upgrades to "Primary school"
+
+#### Test 2: Profile GET Updates Stale Rank
+1. Manually set a user's rank to "Beginner" in DB
+2. Set their subject experiences to total 20000
+3. Call `GET /api/users/profile`
+4. Verify rank is auto-updated to "Secondary school"
+
+#### Test 3: Multiple Rank Jumps
+1. User has 5000 total experience (Beginner)
+2. Update experience to 25000 total
+3. Verify rank jumps directly to "University student"
+
+## Database Schema
+
+No changes required! Uses existing columns:
+
+```sql
+CREATE TABLE "user" (
+    ...
+    rank TEXT DEFAULT 'Beginner',
+    math_exp INT DEFAULT 0,
+    phy_exp INT DEFAULT 0,
+    bio_exp INT DEFAULT 0,
+    chem_exp INT DEFAULT 0,
+    ...
+);
+```
+
+## Performance Considerations
+
+1. **Automatic Updates**: Rank calculation happens in-memory (very fast)
+2. **Conditional Updates**: Database is only updated if rank actually changes
+3. **Single Query**: Rank update happens in same transaction as experience update
+4. **No Additional API Calls**: Transparent to frontend
+
+## Future Enhancements
+
+Potential improvements:
+1. Add rank-up notifications/achievements
+2. Track rank history (when user reached each rank)
+3. Add rank-based rewards or unlockables
+4. Show progress to next rank (e.g., "2000 XP to next rank")
+5. Add rank-specific badges or icons
+6. Leaderboard by rank
+7. Rank decay/maintenance requirements
+
+## Backward Compatibility
+
+✅ **Fully Backward Compatible**
+- No API contract changes
+- No database schema changes
+- Existing rank values will be auto-corrected on next GET/PATCH
+- No breaking changes to response formats
+
+## Migration Strategy
+
+No migration needed, but optionally you can run a one-time script to update all existing user ranks:
+
+```sql
+-- Optional: Update all user ranks to match their current experience
+UPDATE "user"
+SET rank = CASE
+    WHEN (math_exp + phy_exp + bio_exp + chem_exp) < 8000 THEN 'Beginner'
+    WHEN (math_exp + phy_exp + bio_exp + chem_exp) < 16000 THEN 'Primary school'
+    WHEN (math_exp + phy_exp + bio_exp + chem_exp) < 24000 THEN 'Secondary school'
+    WHEN (math_exp + phy_exp + bio_exp + chem_exp) < 32000 THEN 'University student'
+    WHEN (math_exp + phy_exp + bio_exp + chem_exp) < 40000 THEN 'Graduated'
+    ELSE 'Professor'
+END;
+```
+
+This is optional because ranks will auto-update on the next profile retrieval or experience update.

--- a/FLEARN-back/docs/RANK_VISUAL_GUIDE.md
+++ b/FLEARN-back/docs/RANK_VISUAL_GUIDE.md
@@ -1,0 +1,229 @@
+# Rank System Visual Guide
+
+## Rank Progression Flow
+
+```
+           User Gains Experience
+                    ↓
+    ┌───────────────────────────────┐
+    │   Total XP Calculated         │
+    │   math + phy + bio + chem     │
+    └───────────────┬───────────────┘
+                    ↓
+    ┌───────────────────────────────┐
+    │   Rank Level = Total XP / 8000│
+    │   (Using integer division)    │
+    └───────────────┬───────────────┘
+                    ↓
+    ┌───────────────────────────────┐
+    │   Map Level to Rank Name      │
+    └───────────────┬───────────────┘
+                    ↓
+            Update Database
+```
+
+## Rank Ladder
+
+```
+                    🎓 Professor
+                    ┃ Level 5+
+                    ┃ 40,000+ XP
+                    ┃
+                    ┃
+        ════════════╬════════════  40,000 XP
+                    ┃
+                    🎓 Graduated
+                    ┃ Level 4
+                    ┃ 32,000-39,999 XP
+                    ┃
+        ════════════╬════════════  32,000 XP
+                    ┃
+                    🎓 University student
+                    ┃ Level 3
+                    ┃ 24,000-31,999 XP
+                    ┃
+        ════════════╬════════════  24,000 XP
+                    ┃
+                    🎓 Secondary school
+                    ┃ Level 2
+                    ┃ 16,000-23,999 XP
+                    ┃
+        ════════════╬════════════  16,000 XP
+                    ┃
+                    🎓 Primary school
+                    ┃ Level 1
+                    ┃ 8,000-15,999 XP
+                    ┃
+        ════════════╬════════════  8,000 XP
+                    ┃
+                    🎓 Beginner
+                    ┃ Level 0
+                    ┃ 0-7,999 XP
+                    ┃
+        ════════════╩════════════  0 XP
+```
+
+## Experience Distribution Examples
+
+### Example 1: Balanced Learner
+```
+Math:    █████ 5,000 XP
+Physics: █████ 5,000 XP
+Biology: █████ 5,000 XP
+Chemistry:█████ 5,000 XP
+────────────────────────
+Total:   20,000 XP
+Rank:    Secondary school (Level 2)
+```
+
+### Example 2: Math Specialist
+```
+Math:    ████████████████ 15,000 XP
+Physics: ██ 2,000 XP
+Biology: █ 1,000 XP
+Chemistry:██ 2,000 XP
+────────────────────────
+Total:   20,000 XP
+Rank:    Secondary school (Level 2)
+```
+
+### Example 3: University Student
+```
+Math:    ████████ 8,000 XP
+Physics: ███████ 7,000 XP
+Biology: ███████ 7,000 XP
+Chemistry:████████ 8,000 XP
+────────────────────────
+Total:   30,000 XP
+Rank:    University student (Level 3)
+```
+
+### Example 4: Professor
+```
+Math:    ████████████ 12,000 XP
+Physics: ███████████ 11,000 XP
+Biology: ██████████ 10,000 XP
+Chemistry:█████████ 9,000 XP
+────────────────────────
+Total:   42,000 XP
+Rank:    Professor (Level 5)
+```
+
+## Rank Up Scenarios
+
+### Scenario A: Gradual Progress
+```
+Day 1:  5,000 XP  → Beginner
+Day 10: 8,500 XP  → Primary school ⬆️
+Day 20: 16,200 XP → Secondary school ⬆️
+Day 30: 24,100 XP → University student ⬆️
+Day 40: 32,500 XP → Graduated ⬆️
+Day 50: 40,800 XP → Professor ⬆️
+```
+
+### Scenario B: Fast Learner
+```
+Week 1: 0 XP      → Beginner
+Week 2: 15,000 XP → Primary school ⬆️
+Week 3: 25,000 XP → University student ⬆️⬆️ (skipped Secondary)
+Week 4: 41,000 XP → Professor ⬆️⬆️ (skipped Graduated)
+```
+
+## XP Required for Each Rank
+
+| From Beginner    | To Next Rank          | XP Needed |
+|------------------|-----------------------|-----------|
+| Beginner         | → Primary school      | 8,000     |
+| Primary school   | → Secondary school    | 8,000     |
+| Secondary school | → University student  | 8,000     |
+| University student| → Graduated          | 8,000     |
+| Graduated        | → Professor           | 8,000     |
+| Professor        | → (Max Rank)          | -         |
+
+**Total to reach Professor**: 40,000 XP
+
+## API Response Examples
+
+### Low Level
+```json
+{
+  "math_exp": 2000,
+  "phy_exp": 1500,
+  "bio_exp": 1000,
+  "chem_exp": 2500,
+  "rank": "Beginner"
+}
+```
+
+### Mid Level
+```json
+{
+  "math_exp": 5000,
+  "phy_exp": 5000,
+  "bio_exp": 5000,
+  "chem_exp": 5000,
+  "rank": "Secondary school"
+}
+```
+
+### High Level
+```json
+{
+  "math_exp": 12000,
+  "phy_exp": 11000,
+  "bio_exp": 10000,
+  "chem_exp": 9000,
+  "rank": "Professor"
+}
+```
+
+## Calculation Reference Table
+
+| Total XP | ÷ 8000 | Level | Rank Name          |
+|----------|--------|-------|--------------------|
+| 0        | 0.00   | 0     | Beginner           |
+| 4,000    | 0.50   | 0     | Beginner           |
+| 7,999    | 0.99   | 0     | Beginner           |
+| 8,000    | 1.00   | 1     | Primary school     |
+| 12,000   | 1.50   | 1     | Primary school     |
+| 15,999   | 1.99   | 1     | Primary school     |
+| 16,000   | 2.00   | 2     | Secondary school   |
+| 20,000   | 2.50   | 2     | Secondary school   |
+| 23,999   | 2.99   | 2     | Secondary school   |
+| 24,000   | 3.00   | 3     | University student |
+| 28,000   | 3.50   | 3     | University student |
+| 31,999   | 3.99   | 3     | University student |
+| 32,000   | 4.00   | 4     | Graduated          |
+| 36,000   | 4.50   | 4     | Graduated          |
+| 39,999   | 4.99   | 4     | Graduated          |
+| 40,000   | 5.00   | 5     | Professor          |
+| 50,000   | 6.25   | 6     | Professor          |
+| 100,000  | 12.50  | 12    | Professor          |
+
+Note: Level is calculated using `floor()` function (integer division)
+
+## Progress Tracking
+
+### XP to Next Rank Formula
+```javascript
+currentXP = math_exp + phy_exp + bio_exp + chem_exp
+currentLevel = Math.floor(currentXP / 8000)
+nextLevelXP = (currentLevel + 1) * 8000
+xpNeeded = nextLevelXP - currentXP
+progressPercent = ((currentXP % 8000) / 8000) * 100
+```
+
+### Example Calculation
+```
+Current XP: 22,500
+Current Level: floor(22,500 / 8000) = 2 (Secondary school)
+Next Level XP: 3 * 8000 = 24,000
+XP Needed: 24,000 - 22,500 = 1,500
+Progress: (22,500 % 8000) / 8000 = 6,500 / 8000 = 81.25%
+```
+
+Progress bar:
+```
+█████████████████████░░░ 81.25% to University student
+1,500 XP remaining
+```

--- a/FLEARN-back/docs/STREAK_RESET.md
+++ b/FLEARN-back/docs/STREAK_RESET.md
@@ -1,0 +1,212 @@
+# Streak Auto-Reset Functionality
+
+## Overview
+
+This feature automatically resets user and garden streaks to 0 when the `uptime_streak` date is 2 or more days old compared to the current date. The reset happens automatically when data is retrieved via GET endpoints.
+
+## Implementation Details
+
+### Files Modified/Created
+
+1. **`middleware/streakHelper.js`** (NEW)
+   - Contains helper functions for checking and resetting streaks
+   - Functions:
+     - `shouldResetStreak(uptimeStreak)` - Checks if streak should be reset
+     - `resetUserStreakIfNeeded(pgPool, userId, uptimeStreak)` - Resets user streak if needed
+     - `resetGardenStreakIfNeeded(pgPool, gardenId, uptimeStreak)` - Resets garden streak if needed
+     - `checkAndResetUserStreak(pgPool, userId)` - Checks and resets user streak, returns updated user data
+     - `checkAndResetGardenStreak(pgPool, gardenId)` - Checks and resets garden streak, returns updated garden data
+
+2. **`routes/users.js`** (MODIFIED)
+   - Updated `GET /api/users/profile` to check and reset streak on retrieval
+   - Updated `GET /api/users/profilebyid` to check and reset streak on retrieval
+
+3. **`routes/gardens.js`** (MODIFIED)
+   - Updated `GET /api/gardens` to check and reset streaks for all gardens on retrieval
+   - Updated `GET /api/gardens/user/:userId` to check and reset streaks for user's gardens on retrieval
+
+4. **`tests/streakHelper.test.js`** (NEW)
+   - Unit tests for streak reset logic
+
+### Logic
+
+The streak reset logic follows these rules:
+
+1. **No Reset**: If `uptime_streak` is `NULL` or `undefined` → No reset (streak already 0 or never started)
+2. **No Reset**: If `uptime_streak` is today (0 days difference) → No reset
+3. **No Reset**: If `uptime_streak` is yesterday (1 day difference) → No reset
+4. **RESET**: If `uptime_streak` is 2+ days ago (≥2 days difference) → Reset streak to 0 and set `uptime_streak` to `NULL`
+
+### Reset Behavior
+
+When a streak is reset:
+- `streak` field is set to `0`
+- `uptime_streak` field is set to `NULL`
+- `updated_at` timestamp is updated to current time
+
+## API Behavior
+
+### User Profile Endpoints
+
+#### GET /api/users/profile
+**Before**: Returns user profile as-is from database
+**After**: Checks if streak needs reset before returning, automatically resets if condition is met
+
+#### GET /api/users/profilebyid?id={userId}
+**Before**: Returns user profile as-is from database
+**After**: Checks if streak needs reset before returning, automatically resets if condition is met
+
+### Garden Endpoints
+
+#### GET /api/gardens
+**Before**: Returns all user's gardens as-is from database
+**After**: Checks each garden's streak and resets if needed before returning
+
+#### GET /api/gardens/user/{userId}
+**Before**: Returns user's active gardens as-is from database
+**After**: Checks each garden's streak and resets if needed before returning
+
+## Examples
+
+### Example 1: User Profile Streak Reset
+
+**Scenario**: User's `uptime_streak` is 3 days old
+
+**Request**:
+```http
+GET /api/users/profile
+Authorization: Bearer <JWT_TOKEN>
+```
+
+**Response**:
+```json
+{
+  "message": "User profile retrieved successfully",
+  "user": {
+    "user_id": "123e4567-e89b-12d3-a456-426614174000",
+    "name": "John Doe",
+    "streak": 0,          // Reset from previous value
+    "uptime_streak": null, // Reset from old date
+    ...
+  }
+}
+```
+
+### Example 2: Garden Streak Reset
+
+**Scenario**: Garden's `uptime_streak` is 5 days old
+
+**Request**:
+```http
+GET /api/gardens
+Authorization: Bearer <JWT_TOKEN>
+```
+
+**Response**:
+```json
+{
+  "message": "Gardens retrieved successfully",
+  "gardens": [
+    {
+      "row_id": 1,
+      "streak": 0,          // Reset from previous value
+      "uptime_streak": null, // Reset from old date
+      "partner_name": "Jane Doe",
+      ...
+    }
+  ]
+}
+```
+
+### Example 3: No Reset Needed
+
+**Scenario**: User's `uptime_streak` was updated yesterday
+
+**Request**:
+```http
+GET /api/users/profile
+Authorization: Bearer <JWT_TOKEN>
+```
+
+**Response**:
+```json
+{
+  "message": "User profile retrieved successfully",
+  "user": {
+    "user_id": "123e4567-e89b-12d3-a456-426614174000",
+    "name": "John Doe",
+    "streak": 5,                    // Unchanged
+    "uptime_streak": "2025-10-05",  // Yesterday - no reset
+    ...
+  }
+}
+```
+
+## Testing
+
+Run the unit tests for the streak helper:
+
+```bash
+cd FLEARN-back
+npm test tests/streakHelper.test.js
+```
+
+### Test Coverage
+
+The tests cover:
+- ✅ Null/undefined uptime_streak values
+- ✅ Today's date (0 days difference)
+- ✅ Yesterday's date (1 day difference)
+- ✅ 2 days ago (should reset)
+- ✅ 3+ days ago (should reset)
+- ✅ String date formats
+- ✅ ISO string formats
+- ✅ Edge cases
+
+## Database Schema
+
+### User Table
+```sql
+CREATE TABLE "user" (
+    ...
+    streak INT DEFAULT 0,
+    uptime_streak DATE,
+    ...
+);
+```
+
+### Garden Table
+```sql
+CREATE TABLE garden (
+    ...
+    streak INT DEFAULT 0,
+    uptime_streak DATE,
+    ...
+);
+```
+
+## Performance Considerations
+
+1. **Automatic Updates**: Streak resets happen automatically on GET requests, so no additional API calls are needed
+2. **Database Queries**: Each reset requires one additional UPDATE query per entity
+3. **Optimization**: For endpoints returning multiple gardens, updates are performed in parallel using `Promise.all()`
+
+## Future Enhancements
+
+Potential improvements:
+1. Add a scheduled job (cron) to reset streaks in bulk at midnight
+2. Add analytics/logging for streak resets
+3. Send notifications to users when their streak is reset
+4. Add a grace period configuration option
+
+## Migration
+
+No database migration is required as this feature uses existing `streak` and `uptime_streak` columns.
+
+## Backward Compatibility
+
+✅ **Fully Backward Compatible**
+- No API contract changes
+- No database schema changes
+- Existing clients will receive updated data transparently
+- No breaking changes to response formats

--- a/FLEARN-back/docs/STREAK_RESET_FLOW.md
+++ b/FLEARN-back/docs/STREAK_RESET_FLOW.md
@@ -1,0 +1,143 @@
+# Streak Reset Logic Flow
+
+## Decision Tree
+
+```
+┌─────────────────────────────────────┐
+│  User/Garden GET Request Received   │
+└─────────────┬───────────────────────┘
+              │
+              ▼
+┌─────────────────────────────────────┐
+│   Fetch data from database          │
+└─────────────┬───────────────────────┘
+              │
+              ▼
+┌─────────────────────────────────────┐
+│   Check uptime_streak value         │
+└─────────────┬───────────────────────┘
+              │
+              ▼
+      ┌───────┴────────┐
+      │                │
+      ▼                ▼
+┌──────────┐    ┌──────────────┐
+│ NULL or  │    │  Has Date    │
+│Undefined │    │   Value      │
+└────┬─────┘    └──────┬───────┘
+     │                 │
+     │                 ▼
+     │         ┌────────────────────┐
+     │         │ Calculate days     │
+     │         │ difference from    │
+     │         │ today              │
+     │         └────────┬───────────┘
+     │                  │
+     │          ┌───────┴────────┐
+     │          │                │
+     │          ▼                ▼
+     │    ┌──────────┐    ┌──────────┐
+     │    │ 0-1 Days │    │ 2+ Days  │
+     │    └────┬─────┘    └────┬─────┘
+     │         │               │
+     ▼         ▼               ▼
+┌─────────────────────┐  ┌──────────────────┐
+│  No Reset Needed    │  │  Reset Streak    │
+│  Return data as-is  │  │  - streak = 0    │
+│                     │  │  - uptime = NULL │
+└─────────┬───────────┘  └────────┬─────────┘
+          │                       │
+          │                       ▼
+          │              ┌──────────────────┐
+          │              │ UPDATE database  │
+          │              └────────┬─────────┘
+          │                       │
+          └───────────┬───────────┘
+                      │
+                      ▼
+              ┌──────────────────┐
+              │ Return updated   │
+              │ data to client   │
+              └──────────────────┘
+```
+
+## Timeline Examples
+
+### Example 1: No Reset (1 Day)
+```
+Today: Oct 6, 2025
+uptime_streak: Oct 5, 2025 (1 day ago)
+Result: ✅ NO RESET (streak maintained)
+```
+
+### Example 2: Reset (2 Days)
+```
+Today: Oct 6, 2025
+uptime_streak: Oct 4, 2025 (2 days ago)
+Result: ⚠️ RESET (streak = 0, uptime_streak = NULL)
+```
+
+### Example 3: Reset (Many Days)
+```
+Today: Oct 6, 2025
+uptime_streak: Sep 20, 2025 (16 days ago)
+Result: ⚠️ RESET (streak = 0, uptime_streak = NULL)
+```
+
+## Code Flow
+
+### User Profile Request
+```javascript
+GET /api/users/profile
+    ↓
+Fetch user from DB
+    ↓
+checkAndResetUserStreak(pgPool, userId)
+    ↓
+shouldResetStreak(uptime_streak)?
+    ├─ YES → UPDATE user SET streak=0, uptime_streak=NULL
+    └─ NO  → Return data as-is
+    ↓
+Return user data to client
+```
+
+### Garden List Request
+```javascript
+GET /api/gardens
+    ↓
+Fetch gardens from DB (with JOIN)
+    ↓
+For each garden:
+    checkAndResetGardenStreak(pgPool, garden.row_id)
+        ↓
+    shouldResetStreak(uptime_streak)?
+        ├─ YES → UPDATE garden SET streak=0, uptime_streak=NULL
+        └─ NO  → Return data as-is
+    ↓
+Return all gardens to client
+```
+
+## Database Impact
+
+### Before Reset
+```sql
+SELECT streak, uptime_streak FROM "user" WHERE user_id = '...';
+```
+| streak | uptime_streak |
+|--------|---------------|
+| 5      | 2025-10-03    |
+
+### After Reset (Automatic)
+```sql
+SELECT streak, uptime_streak FROM "user" WHERE user_id = '...';
+```
+| streak | uptime_streak |
+|--------|---------------|
+| 0      | NULL          |
+
+## Performance Notes
+
+- **Single User**: 1 SELECT + 0-1 UPDATE queries
+- **Multiple Gardens**: 1 SELECT (JOIN) + N parallel UPDATE queries (if needed)
+- **Optimization**: Updates only happen when reset condition is met
+- **Caching**: Consider implementing caching to reduce database calls

--- a/FLEARN-back/middleware/streakHelper.js
+++ b/FLEARN-back/middleware/streakHelper.js
@@ -1,0 +1,214 @@
+/**
+ * Helper functions for managing streaks and ranks
+ * - Resets streak to 0 if uptime_streak - todayDate >= 2 days
+ * - Calculates and updates user rank based on total subject experience
+ */
+
+/**
+ * Rank thresholds and names
+ * Rank = total(subject_exp) // 8000
+ */
+const RANK_NAMES = [
+    'Beginner',           // Level 0: 0-7999 exp
+    'Primary school',     // Level 1: 8000-15999 exp
+    'Secondary school',   // Level 2: 16000-23999 exp
+    'University student', // Level 3: 24000-31999 exp
+    'Graduated',          // Level 4: 32000-39999 exp
+    'Professor'           // Level 5+: 40000+ exp
+];
+
+const RANK_EXP_DIVISOR = 8000;
+
+/**
+ * Calculate rank based on total subject experience
+ * @param {number} mathExp - Math experience points
+ * @param {number} phyExp - Physics experience points
+ * @param {number} bioExp - Biology experience points
+ * @param {number} chemExp - Chemistry experience points
+ * @returns {string} - Rank name
+ */
+const calculateRank = (mathExp, phyExp, bioExp, chemExp) => {
+    const totalExp = (mathExp || 0) + (phyExp || 0) + (bioExp || 0) + (chemExp || 0);
+    const rankLevel = Math.floor(totalExp / RANK_EXP_DIVISOR);
+    
+    // Cap at highest rank
+    const cappedLevel = Math.min(rankLevel, RANK_NAMES.length - 1);
+    
+    return RANK_NAMES[cappedLevel];
+};
+
+/**
+ * Check if a streak should be reset based on the last update date
+ * @param {Date|string} uptimeStreak - The last streak update date
+ * @returns {boolean} - True if streak should be reset
+ */
+const shouldResetStreak = (uptimeStreak) => {
+    if (!uptimeStreak) {
+        return false; // No uptime_streak means streak is already 0 or never started
+    }
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0); // Reset to start of day for accurate comparison
+    
+    const lastUpdate = new Date(uptimeStreak);
+    lastUpdate.setHours(0, 0, 0, 0);
+    
+    // Calculate difference in days
+    const diffTime = today - lastUpdate;
+    const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+    
+    // Reset if 2 or more days have passed
+    return diffDays >= 2;
+};
+
+/**
+ * Reset user streak if needed
+ * @param {object} pgPool - PostgreSQL connection pool
+ * @param {string} userId - User ID
+ * @param {Date|string} uptimeStreak - Current uptime_streak value
+ * @returns {Promise<boolean>} - True if streak was reset
+ */
+const resetUserStreakIfNeeded = async (pgPool, userId, uptimeStreak) => {
+    if (shouldResetStreak(uptimeStreak)) {
+        const updateQuery = `
+            UPDATE "user" 
+            SET streak = 0, 
+                uptime_streak = NULL,
+                updated_at = NOW()
+            WHERE user_id = $1
+        `;
+        
+        await pgPool.query(updateQuery, [userId]);
+        return true;
+    }
+    return false;
+};
+
+/**
+ * Reset garden streak if needed
+ * @param {object} pgPool - PostgreSQL connection pool
+ * @param {number} gardenId - Garden row_id
+ * @param {Date|string} uptimeStreak - Current uptime_streak value
+ * @returns {Promise<boolean>} - True if streak was reset
+ */
+const resetGardenStreakIfNeeded = async (pgPool, gardenId, uptimeStreak) => {
+    if (shouldResetStreak(uptimeStreak)) {
+        const updateQuery = `
+            UPDATE garden 
+            SET streak = 0, 
+                uptime_streak = NULL,
+                updated_at = NOW()
+            WHERE row_id = $1
+        `;
+        
+        await pgPool.query(updateQuery, [gardenId]);
+        return true;
+    }
+    return false;
+};
+
+/**
+ * Update user rank based on subject experience
+ * @param {object} pgPool - PostgreSQL connection pool
+ * @param {string} userId - User ID
+ * @param {object} user - User object with experience fields
+ * @returns {Promise<boolean>} - True if rank was updated
+ */
+const updateUserRankIfNeeded = async (pgPool, userId, user) => {
+    const currentRank = user.rank;
+    const calculatedRank = calculateRank(
+        user.math_exp,
+        user.phy_exp,
+        user.bio_exp,
+        user.chem_exp
+    );
+    
+    // Only update if rank has changed
+    if (currentRank !== calculatedRank) {
+        const updateQuery = `
+            UPDATE "user" 
+            SET rank = $1, 
+                updated_at = NOW()
+            WHERE user_id = $2
+        `;
+        
+        await pgPool.query(updateQuery, [calculatedRank, userId]);
+        return true;
+    }
+    
+    return false;
+};
+
+/**
+ * Check and reset streak for a user, returning updated user data
+ * Also updates rank based on experience
+ * @param {object} pgPool - PostgreSQL connection pool
+ * @param {string} userId - User ID
+ * @returns {Promise<object|null>} - Updated user object or null if not found
+ */
+const checkAndResetUserStreak = async (pgPool, userId) => {
+    // Get current user data
+    const selectQuery = `SELECT * FROM "user" WHERE user_id = $1`;
+    const result = await pgPool.query(selectQuery, [userId]);
+    
+    if (result.rows.length === 0) {
+        return null;
+    }
+    
+    const user = result.rows[0];
+    
+    // Check if streak reset is needed
+    const streakWasReset = await resetUserStreakIfNeeded(pgPool, userId, user.uptime_streak);
+    
+    // Check if rank update is needed
+    const rankWasUpdated = await updateUserRankIfNeeded(pgPool, userId, user);
+    
+    // If either was updated, fetch fresh data
+    if (streakWasReset || rankWasUpdated) {
+        const updatedResult = await pgPool.query(selectQuery, [userId]);
+        return updatedResult.rows[0];
+    }
+    
+    return user;
+};
+
+/**
+ * Check and reset streak for a garden, returning updated garden data
+ * @param {object} pgPool - PostgreSQL connection pool
+ * @param {number} gardenId - Garden row_id
+ * @returns {Promise<object|null>} - Updated garden object or null if not found
+ */
+const checkAndResetGardenStreak = async (pgPool, gardenId) => {
+    // Get current garden data
+    const selectQuery = `SELECT * FROM garden WHERE row_id = $1`;
+    const result = await pgPool.query(selectQuery, [gardenId]);
+    
+    if (result.rows.length === 0) {
+        return null;
+    }
+    
+    const garden = result.rows[0];
+    
+    // Check if reset is needed
+    const wasReset = await resetGardenStreakIfNeeded(pgPool, gardenId, garden.uptime_streak);
+    
+    if (wasReset) {
+        // Fetch updated garden data
+        const updatedResult = await pgPool.query(selectQuery, [gardenId]);
+        return updatedResult.rows[0];
+    }
+    
+    return garden;
+};
+
+module.exports = {
+    shouldResetStreak,
+    resetUserStreakIfNeeded,
+    resetGardenStreakIfNeeded,
+    checkAndResetUserStreak,
+    checkAndResetGardenStreak,
+    calculateRank,
+    updateUserRankIfNeeded,
+    RANK_NAMES,
+    RANK_EXP_DIVISOR
+};

--- a/FLEARN-back/routes/gardens.js
+++ b/FLEARN-back/routes/gardens.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { pgPool } = require('../config/database');
 const { checkJwt } = require('../middleware/auth');
+const { checkAndResetGardenStreak } = require('../middleware/streakHelper');
 
 const router = express.Router();
 
@@ -60,9 +61,24 @@ router.get('/', checkJwt, async (req, res) => {
         
         const result = await pgPool.query(query, [userId]);
         
+        // Check and reset streak for each garden if needed (if uptime_streak - todayDate >= 2 days)
+        const updatedGardens = await Promise.all(
+            result.rows.map(async (garden) => {
+                const updatedGarden = await checkAndResetGardenStreak(pgPool, garden.row_id);
+                // Preserve the joined fields from the original query
+                return {
+                    ...updatedGarden,
+                    partner_name: garden.partner_name,
+                    partner_email: garden.partner_email,
+                    partner_profile_pic: garden.partner_profile_pic,
+                    partner_user_id: garden.partner_user_id
+                };
+            })
+        );
+        
         res.json({
             message: 'Gardens retrieved successfully',
-            gardens: result.rows
+            gardens: updatedGardens
         });
         
     } catch (error) {
@@ -135,9 +151,24 @@ router.get('/user/:userId', checkJwt, async (req, res) => {
         
         const result = await pgPool.query(query, [userId]);
         
+        // Check and reset streak for each garden if needed (if uptime_streak - todayDate >= 2 days)
+        const updatedGardens = await Promise.all(
+            result.rows.map(async (garden) => {
+                const updatedGarden = await checkAndResetGardenStreak(pgPool, garden.row_id);
+                // Preserve the joined fields from the original query
+                return {
+                    ...updatedGarden,
+                    partner_name: garden.partner_name,
+                    partner_email: garden.partner_email,
+                    partner_profile_pic: garden.partner_profile_pic,
+                    partner_user_id: garden.partner_user_id
+                };
+            })
+        );
+        
         res.json({
             message: 'Gardens retrieved successfully',
-            gardens: result.rows
+            gardens: updatedGardens
         });
         
     } catch (error) {

--- a/FLEARN-back/routes/users.js
+++ b/FLEARN-back/routes/users.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { pgPool } = require('../config/database');
 const { checkJwt, optionalJwt } = require('../middleware/auth');
 const { v4: uuidv4 } = require('uuid');
+const { checkAndResetUserStreak, calculateRank } = require('../middleware/streakHelper');
 
 const router = express.Router();
 
@@ -27,7 +28,9 @@ router.get('/profile', checkJwt, async (req, res) => {
             });
         }
         
-        const user = result.rows[0];
+        // Check and reset streak if needed (if uptime_streak - todayDate >= 2 days)
+        const user = await checkAndResetUserStreak(pgPool, result.rows[0].user_id);
+        
         res.json({
             message: 'User profile retrieved successfully',
             user: user
@@ -68,7 +71,9 @@ router.get('/profilebyid', checkJwt, async (req, res) => {
             });
         }
         
-        const user = result.rows[0];
+        // Check and reset streak if needed (if uptime_streak - todayDate >= 2 days)
+        const user = await checkAndResetUserStreak(pgPool, userId);
+        
         res.json({
             message: 'User profile retrieved successfully',
             user: user
@@ -430,6 +435,28 @@ router.patch('/experience', checkJwt, async (req, res) => {
         const googleId = req.user.sub || req.user.id;
         const { daily_exp, math_exp, phy_exp, bio_exp, chem_exp } = req.body;
         
+        // First, get current user data
+        const getUserQuery = `SELECT * FROM "user" WHERE google_id = $1`;
+        const userResult = await pgPool.query(getUserQuery, [googleId]);
+        
+        if (userResult.rows.length === 0) {
+            return res.status(404).json({
+                error: 'User not found',
+                message: 'Please complete your profile setup first'
+            });
+        }
+        
+        const currentUser = userResult.rows[0];
+        
+        // Calculate new experience values
+        const newMathExp = math_exp !== undefined ? math_exp : currentUser.math_exp;
+        const newPhyExp = phy_exp !== undefined ? phy_exp : currentUser.phy_exp;
+        const newBioExp = bio_exp !== undefined ? bio_exp : currentUser.bio_exp;
+        const newChemExp = chem_exp !== undefined ? chem_exp : currentUser.chem_exp;
+        
+        // Calculate new rank based on total subject experience
+        const newRank = calculateRank(newMathExp, newPhyExp, newBioExp, newChemExp);
+        
         const updateQuery = `
             UPDATE "user" 
             SET daily_exp = COALESCE($1, daily_exp),
@@ -437,24 +464,18 @@ router.patch('/experience', checkJwt, async (req, res) => {
                 phy_exp = COALESCE($3, phy_exp),
                 bio_exp = COALESCE($4, bio_exp),
                 chem_exp = COALESCE($5, chem_exp),
+                rank = $6,
                 updated_at = NOW()
-            WHERE google_id = $6
+            WHERE google_id = $7
             RETURNING *
         `;
         
         const result = await pgPool.query(updateQuery, [
-            daily_exp, math_exp, phy_exp, bio_exp, chem_exp, googleId
+            daily_exp, math_exp, phy_exp, bio_exp, chem_exp, newRank, googleId
         ]);
         
-        if (result.rows.length === 0) {
-            return res.status(404).json({
-                error: 'User not found',
-                message: 'Please complete your profile setup first'
-            });
-        }
-        
         res.json({
-            message: 'Experience points updated successfully',
+            message: 'Experience points and rank updated successfully',
             user: result.rows[0]
         });
         

--- a/FLEARN-back/tests/streakHelper.test.js
+++ b/FLEARN-back/tests/streakHelper.test.js
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for streak helper functions and rank calculation
+ */
+
+const { shouldResetStreak, calculateRank, RANK_NAMES, RANK_EXP_DIVISOR } = require('../middleware/streakHelper');
+
+describe('Streak Helper Tests', () => {
+    describe('shouldResetStreak', () => {
+        test('should return false if uptime_streak is null', () => {
+            expect(shouldResetStreak(null)).toBe(false);
+        });
+
+        test('should return false if uptime_streak is undefined', () => {
+            expect(shouldResetStreak(undefined)).toBe(false);
+        });
+
+        test('should return false if uptime_streak is today', () => {
+            const today = new Date();
+            expect(shouldResetStreak(today)).toBe(false);
+        });
+
+        test('should return false if uptime_streak is yesterday (1 day ago)', () => {
+            const yesterday = new Date();
+            yesterday.setDate(yesterday.getDate() - 1);
+            expect(shouldResetStreak(yesterday)).toBe(false);
+        });
+
+        test('should return true if uptime_streak is 2 days ago', () => {
+            const twoDaysAgo = new Date();
+            twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+            expect(shouldResetStreak(twoDaysAgo)).toBe(true);
+        });
+
+        test('should return true if uptime_streak is 3 days ago', () => {
+            const threeDaysAgo = new Date();
+            threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+            expect(shouldResetStreak(threeDaysAgo)).toBe(true);
+        });
+
+        test('should return true if uptime_streak is 10 days ago', () => {
+            const tenDaysAgo = new Date();
+            tenDaysAgo.setDate(tenDaysAgo.getDate() - 10);
+            expect(shouldResetStreak(tenDaysAgo)).toBe(true);
+        });
+
+        test('should handle string date format', () => {
+            const twoDaysAgo = new Date();
+            twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+            const dateString = twoDaysAgo.toISOString().split('T')[0];
+            expect(shouldResetStreak(dateString)).toBe(true);
+        });
+
+        test('should handle ISO string date format', () => {
+            const twoDaysAgo = new Date();
+            twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+            const isoString = twoDaysAgo.toISOString();
+            expect(shouldResetStreak(isoString)).toBe(true);
+        });
+
+        test('edge case: should return false for date exactly 1.5 days ago', () => {
+            const oneDayHalfAgo = new Date();
+            oneDayHalfAgo.setDate(oneDayHalfAgo.getDate() - 1);
+            oneDayHalfAgo.setHours(oneDayHalfAgo.getHours() - 12);
+            // Note: This should still be false because the calculation uses floor,
+            // so 1.5 days = floor(1.5) = 1 day
+            expect(shouldResetStreak(oneDayHalfAgo)).toBe(false);
+        });
+    });
+
+    describe('Rank Calculation', () => {
+        describe('calculateRank', () => {
+            test('should return "Beginner" for 0 total exp', () => {
+                expect(calculateRank(0, 0, 0, 0)).toBe('Beginner');
+            });
+
+            test('should return "Beginner" for exp < 8000', () => {
+                expect(calculateRank(2000, 1000, 1500, 3000)).toBe('Beginner'); // 7500 total
+                expect(calculateRank(1999, 1999, 1999, 1999)).toBe('Beginner'); // 7996 total
+            });
+
+            test('should return "Primary school" for exp 8000-15999', () => {
+                expect(calculateRank(8000, 0, 0, 0)).toBe('Primary school'); // 8000 total
+                expect(calculateRank(2000, 2000, 2000, 2000)).toBe('Primary school'); // 8000 total
+                expect(calculateRank(5000, 5000, 5000, 0)).toBe('Primary school'); // 15000 total
+            });
+
+            test('should return "Secondary school" for exp 16000-23999', () => {
+                expect(calculateRank(16000, 0, 0, 0)).toBe('Secondary school'); // 16000 total
+                expect(calculateRank(4000, 4000, 4000, 4000)).toBe('Secondary school'); // 16000 total
+                expect(calculateRank(10000, 6000, 4000, 3000)).toBe('Secondary school'); // 23000 total
+            });
+
+            test('should return "University student" for exp 24000-31999', () => {
+                expect(calculateRank(24000, 0, 0, 0)).toBe('University student'); // 24000 total
+                expect(calculateRank(6000, 6000, 6000, 6000)).toBe('University student'); // 24000 total
+                expect(calculateRank(10000, 10000, 10000, 1000)).toBe('University student'); // 31000 total
+            });
+
+            test('should return "Graduated" for exp 32000-39999', () => {
+                expect(calculateRank(32000, 0, 0, 0)).toBe('Graduated'); // 32000 total
+                expect(calculateRank(8000, 8000, 8000, 8000)).toBe('Graduated'); // 32000 total
+                expect(calculateRank(15000, 12000, 10000, 2000)).toBe('Graduated'); // 39000 total
+            });
+
+            test('should return "Professor" for exp >= 40000', () => {
+                expect(calculateRank(40000, 0, 0, 0)).toBe('Professor'); // 40000 total
+                expect(calculateRank(10000, 10000, 10000, 10000)).toBe('Professor'); // 40000 total
+                expect(calculateRank(50000, 25000, 15000, 10000)).toBe('Professor'); // 100000 total
+                expect(calculateRank(100000, 100000, 100000, 100000)).toBe('Professor'); // 400000 total
+            });
+
+            test('should handle null/undefined values as 0', () => {
+                expect(calculateRank(null, null, null, null)).toBe('Beginner');
+                expect(calculateRank(undefined, undefined, undefined, undefined)).toBe('Beginner');
+                expect(calculateRank(8000, null, undefined, 0)).toBe('Primary school'); // 8000 total
+            });
+
+            test('edge case: exactly at rank boundaries', () => {
+                expect(calculateRank(7999, 0, 0, 0)).toBe('Beginner'); // Just below 8000
+                expect(calculateRank(8000, 0, 0, 0)).toBe('Primary school'); // Exactly 8000
+                expect(calculateRank(15999, 0, 0, 0)).toBe('Primary school'); // Just below 16000
+                expect(calculateRank(16000, 0, 0, 0)).toBe('Secondary school'); // Exactly 16000
+                expect(calculateRank(23999, 0, 0, 0)).toBe('Secondary school'); // Just below 24000
+                expect(calculateRank(24000, 0, 0, 0)).toBe('University student'); // Exactly 24000
+                expect(calculateRank(31999, 0, 0, 0)).toBe('University student'); // Just below 32000
+                expect(calculateRank(32000, 0, 0, 0)).toBe('Graduated'); // Exactly 32000
+                expect(calculateRank(39999, 0, 0, 0)).toBe('Graduated'); // Just below 40000
+                expect(calculateRank(40000, 0, 0, 0)).toBe('Professor'); // Exactly 40000
+            });
+
+            test('should use correct divisor (8000)', () => {
+                expect(RANK_EXP_DIVISOR).toBe(8000);
+                expect(calculateRank(RANK_EXP_DIVISOR * 0, 0, 0, 0)).toBe(RANK_NAMES[0]);
+                expect(calculateRank(RANK_EXP_DIVISOR * 1, 0, 0, 0)).toBe(RANK_NAMES[1]);
+                expect(calculateRank(RANK_EXP_DIVISOR * 2, 0, 0, 0)).toBe(RANK_NAMES[2]);
+                expect(calculateRank(RANK_EXP_DIVISOR * 3, 0, 0, 0)).toBe(RANK_NAMES[3]);
+                expect(calculateRank(RANK_EXP_DIVISOR * 4, 0, 0, 0)).toBe(RANK_NAMES[4]);
+                expect(calculateRank(RANK_EXP_DIVISOR * 5, 0, 0, 0)).toBe(RANK_NAMES[5]);
+            });
+
+            test('should have correct rank names', () => {
+                expect(RANK_NAMES).toEqual([
+                    'Beginner',
+                    'Primary school',
+                    'Secondary school',
+                    'University student',
+                    'Graduated',
+                    'Professor'
+                ]);
+            });
+        });
+
+        describe('Real-world scenarios', () => {
+            test('balanced learner scenario', () => {
+                // Student with balanced learning across subjects
+                expect(calculateRank(5000, 5000, 5000, 5000)).toBe('Secondary school'); // 20000 total
+            });
+
+            test('math specialist scenario', () => {
+                // Student focusing on math
+                expect(calculateRank(15000, 3000, 2000, 1000)).toBe('Secondary school'); // 21000 total
+            });
+
+            test('advanced student scenario', () => {
+                // Advanced student who has graduated
+                expect(calculateRank(10000, 9000, 8000, 7000)).toBe('Graduated'); // 34000 total
+            });
+
+            test('professor level scenario', () => {
+                // Expert with extensive knowledge
+                expect(calculateRank(12000, 11000, 10000, 9000)).toBe('Professor'); // 42000 total
+            });
+        });
+    });
+});


### PR DESCRIPTION
- Add streak auto-reset (resets to 0 if uptime_streak >= 2 days old)
  - Applied to user profiles and gardens on GET requests
  - Automatic and transparent to frontend

- Add rank auto-calculation (based on total subject experience)
  - Formula: rank = floor(total_exp / 8000)
  - Ranks: Beginner, Primary school, Secondary school, University student, Graduated, Professor
  - Updates on experience PATCH and profile GET requests

- Create middleware/streakHelper.js with helper functions
- Add comprehensive unit tests (25 tests, all passing)
- Add detailed documentation in docs/
- Delete README-docker.md

Files added:
- middleware/streakHelper.js
- tests/streakHelper.test.js
- docs/STREAK_RESET.md
- docs/RANK_CALCULATION.md
- docs/STREAK_RESET_FLOW.md
- docs/RANK_VISUAL_GUIDE.md
- AUTO_UPDATE_FEATURES_SUMMARY.md
- QUICK_REFERENCE.md

Files modified:
- routes/users.js
- routes/gardens.js

Files deleted:
- README-docker.md